### PR TITLE
Increase Yii2 ver due to security vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=7.2.0",
-    "yiisoft/yii2": "2.0.14",
+    "yiisoft/yii2": "2.0.38",
     "yiithings/yii2-dotenv": "*",
     "2amigos/yii2-usuario": "1.0.0",
     "yiisoft/yii2-bootstrap": "2.0.8",


### PR DESCRIPTION
Increase Yii2 version to 2.0.38 to fix the following vulnerability: https://github.com/advisories/GHSA-699q-wcff-g9mj